### PR TITLE
Show Merino suggestions in the awesomebar

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
 		BA6E311FBCA7A2157F48568A /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E371A3948814CAA0C83E4 /* Telemetry.swift */; };
 		BA6E3BF4B5AC115E7DBCAA5E /* FxATelemtryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E376117A53502756759A2 /* FxATelemtryTests.swift */; };
+		BCC7FA85296E1F5F00DD4B6C /* MerinoSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC7FA84296E1F5F00DD4B6C /* MerinoSettingsViewController.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
 		C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */; };
 		C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C45F44681D087DB600CB7EF0 /* TopTabsViewController.swift */; };
@@ -3866,6 +3867,7 @@
 		BBF04862A944340C80C053E0 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
+		BCC7FA84296E1F5F00DD4B6C /* MerinoSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoSettingsViewController.swift; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BD2A4E1791139257129D9DE2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		BD514C7EA4DD08E991E5AF7F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -5797,6 +5799,7 @@
 				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
 				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
 				4346FF07295BA6A200F4D220 /* CreditCardSettingsViewController.swift */,
+				BCC7FA84296E1F5F00DD4B6C /* MerinoSettingsViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -10684,6 +10687,7 @@
 				8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,
+				BCC7FA85296E1F5F00DD4B6C /* MerinoSettingsViewController.swift in Sources */,
 				5A430D792853DFDD00782BFF /* OrientationLockUtility.swift in Sources */,
 				D5D237782640BBA600326204 /* ExperimentsSettingsViewController.swift in Sources */,
 				D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */,

--- a/Client/Extensions/String+Extension.swift
+++ b/Client/Extensions/String+Extension.swift
@@ -5,11 +5,24 @@
 import Foundation
 
 extension String {
-    /// Handles logic to make part of string bold
+    /// Returns an attributed string in which the first occurrence of the given
+    /// substring is bold.
     /// - Parameters:
-    ///     - boldString: the portion of the string that should be bold. Current string must already include this string.
+    ///     - boldString: the substring that should be bold
     ///     - font: font for entire string, part of string will be converted to bold version of this font
     func attributedText(boldString: String, font: UIFont) -> NSAttributedString {
+        guard let range = self.range(of: boldString) else {
+            return NSAttributedString(string: self)
+        }
+        return self.attributedText(boldIn: range, font: font)
+    }
+
+    /// Returns an attributed string in which the characters in the given range
+    /// are bold.
+    /// - Parameters:
+    ///     - boldIn: the character range in the string that should be bold
+    ///     - font: font for entire string, part of string will be converted to bold version of this font
+    func attributedText(boldIn range: Range<String.Index>, font: UIFont) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self,
                                                          attributes: [NSAttributedString.Key.font: font])
 
@@ -22,8 +35,7 @@ extension String {
         }
 
         let boldFontAttribute = [NSAttributedString.Key.font: boldFont]
-        let range = (self as NSString).range(of: boldString)
-        attributedString.addAttributes(boldFontAttribute, range: range)
+        attributedString.addAttributes(boldFontAttribute, range: NSRange(range, in: self))
         return attributedString
     }
 }

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -19,6 +19,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case inactiveTabs
     case jumpBackIn
     case jumpBackInSyncedTab
+    case merino
     case onboardingUpgrade
     case onboardingFreshInstall
     case pocket
@@ -84,6 +85,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.TopSiteSection
         case .wallpapers:
             return FlagKeys.CustomWallpaper
+        case .merino:
+            return FlagKeys.Merino
 
         // Cases where users do not have the option to manipulate a setting.
         case .contextualHintForJumpBackInSyncedTab,

--- a/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -33,11 +33,15 @@ class SearchEngines {
     private let showSearchSuggestionsOptIn = "search.suggestions.showOptIn"
     private let showSearchSuggestions = "search.suggestions.show"
     private let customSearchEnginesFileName = "customEngines.plist"
+    private let showSponsoredSuggestions = "search.suggest.showSponsored"
+    private let showNonSponsoredSuggestions = "search.suggest.showNonSponsored"
 
     init(prefs: Prefs, files: FileAccessor) {
         self.prefs = prefs
         // By default, show search suggestions
         self.shouldShowSearchSuggestions = prefs.boolForKey(showSearchSuggestions) ?? true
+        self.shouldShowSponsoredSuggestions = prefs.boolForKey(showSponsoredSuggestions) ?? false
+        self.shouldShowNonSponsoredSuggestions = prefs.boolForKey(showNonSponsoredSuggestions) ?? false
         self.fileAccessor = files
         self.disabledEngines = getDisabledEngines()
         self.orderedEngines = getOrderedEngines()
@@ -82,6 +86,18 @@ class SearchEngines {
     var shouldShowSearchSuggestions: Bool {
         didSet {
             self.prefs.setObject(shouldShowSearchSuggestions, forKey: showSearchSuggestions)
+        }
+    }
+
+    var shouldShowSponsoredSuggestions: Bool {
+        didSet {
+            self.prefs.setObject(shouldShowSponsoredSuggestions, forKey: showSponsoredSuggestions)
+        }
+    }
+
+    var shouldShowNonSponsoredSuggestions: Bool {
+        didSet {
+            self.prefs.setObject(shouldShowNonSponsoredSuggestions, forKey: showNonSponsoredSuggestions)
         }
     }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -640,8 +640,7 @@ class SearchViewController: SiteTableViewController,
         let range = searchPhrase.range(of: query)
         guard searchPhrase != query, let upperBound = range?.upperBound else { return nil }
 
-        let boldString = String(searchPhrase[upperBound..<searchPhrase.endIndex])
-        let attributedString = searchPhrase.attributedText(boldString: boldString,
+        let attributedString = searchPhrase.attributedText(boldIn: upperBound..<searchPhrase.endIndex,
                                                            font: DynamicFontHelper().DefaultStandardFont)
         return attributedString
     }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -177,9 +177,17 @@ class SearchViewController: SiteTableViewController,
     private func loadMerinoSuggestions() {
         self.merinoClientFetchWork?.cancel()
 
+        let showSponsored = searchEngines.shouldShowSponsoredSuggestions
+        let showNonSponsored = searchEngines.shouldShowNonSponsoredSuggestions
+        guard showSponsored || showNonSponsored else {
+            return
+        }
+
         let searchQuery = self.searchQuery
         let fetchWork = DispatchWorkItem { [weak self] in
-            guard let suggestions = try? self?.merinoClient.fetch(query: searchQuery) else {
+            guard let suggestions = try? self?.merinoClient.fetch(query: searchQuery).filter({
+                (showSponsored && $0.isSponsored) || (showNonSponsored && !$0.isSponsored)
+            }) else {
                 return
             }
             DispatchQueue.main.async {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -90,7 +90,8 @@ class SearchViewController: SiteTableViewController,
     private let merinoClientQueue: DispatchQueueInterface
     private var merinoClientFetchWork: DispatchWorkItem?
     private lazy var merinoClient: MerinoClient = {
-        let settings = MerinoClientSettings(server: .production, sessionDurationMs: 5000)
+        let server = profile.prefs.stringForKey(PrefsKeys.CustomMerinoServerURL).map(MerinoServer.custom(url:)) ?? .production
+        let settings = MerinoClientSettings(server: server, sessionDurationMs: 5000)
         return try! MerinoClient(settings: settings)
     }()
 
@@ -179,7 +180,8 @@ class SearchViewController: SiteTableViewController,
 
         let showSponsored = searchEngines.shouldShowSponsoredSuggestions
         let showNonSponsored = searchEngines.shouldShowNonSponsoredSuggestions
-        guard showSponsored || showNonSponsored else {
+        guard featureFlags.isFeatureEnabled(.merino, checking: .userOnly),
+              showSponsored || showNonSponsored else {
             return
         }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -813,8 +813,21 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.leftImageView.contentMode = .center
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
+                let currentGenerationNumber = twoLineCell.generationNumber
                 if let iconURL = suggestion.details.icon.flatMap({ URL(string: $0) }) {
-                    twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(faviconURL: iconURL))
+                    DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(with: iconURL,
+                                                                                  limit: 0) { [weak twoLineCell] image, error in
+                        guard error == nil, let image = image else {
+                            return
+                        }
+                        DispatchQueue.main.async {
+                            guard twoLineCell?.generationNumber == currentGenerationNumber else {
+                                return
+                            }
+                            twoLineCell?.leftImageView.image = image.createScaled(CGSize(width: SearchViewControllerUX.IconSize,
+                                                                                         height: SearchViewControllerUX.IconSize))
+                        }
+                    }
                 } else {
                     twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: suggestion.details.url))
                 }
@@ -832,8 +845,21 @@ class SearchViewController: SiteTableViewController,
             oneLineCell.leftImageView.contentMode = .center
             oneLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
             oneLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
+            let currentGenerationNumber = oneLineCell.generationNumber
             if let iconURL = suggestion.details.icon.flatMap({ URL(string: $0) }) {
-                oneLineCell.leftImageView.setFavicon(FaviconImageViewModel(faviconURL: iconURL))
+                DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(with: iconURL,
+                                                                              limit: 0) { [weak oneLineCell] image, error in
+                    guard error == nil, let image = image else {
+                        return
+                    }
+                    DispatchQueue.main.async {
+                        guard oneLineCell?.generationNumber == currentGenerationNumber else {
+                            return
+                        }
+                        oneLineCell?.leftImageView.image = image.createScaled(CGSize(width: SearchViewControllerUX.IconSize,
+                                                                                     height: SearchViewControllerUX.IconSize))
+                    }
+                }
             } else {
                 oneLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: suggestion.details.url))
             }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1381,3 +1381,25 @@ class SearchBarSetting: Setting {
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
+
+class MerinoSettings: HiddenSetting {
+    let profile: Profile
+
+    override var accessoryView: UIImageView? { SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+
+    override var title: NSAttributedString? {
+        // Not localized for now.
+        NSAttributedString(string: "Merino", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+    }
+
+    override init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(settings: settings)
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let viewController = MerinoSettingsViewController()
+        viewController.profile = profile
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -232,7 +232,8 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                 ToggleHistoryGroups(settings: self),
                 ResetContextualHints(settings: self),
                 OpenFiftyTabsDebugOption(settings: self),
-                ExperimentsSettings(settings: self)
+                ExperimentsSettings(settings: self),
+                MerinoSettings(settings: self),
             ])]
 
         return settings

--- a/Client/Frontend/Settings/MerinoSettingsViewController.swift
+++ b/Client/Frontend/Settings/MerinoSettingsViewController.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Shared
+
+class MerinoSettingsViewController: SettingsTableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Merino"
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let prefs = profile.prefs
+
+        let attributes = [NSAttributedString.Key.foregroundColor: themeManager.currentTheme.colors.textPrimary]
+        let enabled = BoolSetting(
+            prefs: prefs,
+            prefKey: PrefsKeys.FeatureFlags.Merino,
+            defaultValue: false,
+            attributedTitleText: NSAttributedString(
+                string: "Enable Merino",
+                attributes: attributes)
+        ) { isOn in
+            self.settings = self.generateSettings()
+            self.tableView.reloadData()
+        }
+
+        let customServerURL = WebPageSetting(
+            prefs: prefs,
+            prefKey: PrefsKeys.CustomMerinoServerURL,
+            placeholder: "Custom Merino server URL",
+            accessibilityIdentifier: "CustomMerinoServer"
+        )
+        customServerURL.textField.clearButtonMode = .always
+
+        var sections: [SettingSection] = [SettingSection(title: nil, children: [enabled])]
+        if prefs.boolForKey(PrefsKeys.FeatureFlags.Merino) ?? false {
+            sections.append(SettingSection(title: nil, children: [customServerURL]))
+        }
+        return sections
+    }
+}

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -9,7 +9,7 @@ protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?, didSelectSearchEngine engine: OpenSearchEngine?)
 }
 
-class SearchSettingsTableViewController: ThemedTableViewController {
+class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlaggable {
     fileprivate let SectionDefault = 0
     fileprivate let ItemDefaultEngine = 0
     fileprivate let ItemDefaultSuggestions = 1
@@ -20,7 +20,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     fileprivate let ItemShowNonSponsoredSuggestions = 0
     fileprivate let ItemShowSponsoredSuggestions = 1
     fileprivate let NumberOfItemsInSectionSuggest = 2
-    fileprivate let NumberOfSections = 3
+    fileprivate var NumberOfSections: Int {
+        return featureFlags.isFeatureEnabled(.merino, checking: .userOnly) ? 3 : 2
+    }
     fileprivate let IconSize = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
                                       height: OpenSearchEngine.UX.preferredIconSize)
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -16,7 +16,11 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     fileprivate let ItemAddCustomSearch = 2
     fileprivate let NumberOfItemsInSectionDefault = 2
     fileprivate let SectionOrder = 1
-    fileprivate let NumberOfSections = 2
+    fileprivate let SectionSuggest = 2
+    fileprivate let ItemShowNonSponsoredSuggestions = 0
+    fileprivate let ItemShowSponsoredSuggestions = 1
+    fileprivate let NumberOfItemsInSectionSuggest = 2
+    fileprivate let NumberOfSections = 3
     fileprivate let IconSize = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
                                       height: OpenSearchEngine.UX.preferredIconSize)
 
@@ -103,7 +107,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 // Should not happen.
                 break
             }
-        } else {
+        } else if indexPath.section == SectionOrder {
             // The default engine is not a quick search engine.
             let index = indexPath.item + 1
             if index < model.orderedEngines.count {
@@ -132,6 +136,30 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
                 cell.textLabel?.text = .SettingsAddCustomEngine
             }
+        } else if indexPath.section == SectionSuggest {
+            switch indexPath.item {
+            case ItemShowSponsoredSuggestions:
+                cell.textLabel?.text = .SearchSettingsShowSponsoredSuggestionsLabel
+                cell.textLabel?.numberOfLines = 0
+                let toggle = UISwitch()
+                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                toggle.addTarget(self, action: #selector(didToggleSponsoredSuggestions), for: .valueChanged)
+                toggle.isOn = model.shouldShowSponsoredSuggestions
+                cell.editingAccessoryView = toggle
+                cell.selectionStyle = .none
+            case ItemShowNonSponsoredSuggestions:
+                cell.textLabel?.text = .SearchSettingsShowNonSponsoredSuggestionsLabel
+                cell.textLabel?.numberOfLines = 0
+                let toggle = UISwitch()
+                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                toggle.addTarget(self, action: #selector(didToggleNonSponsoredSuggestions), for: .valueChanged)
+                toggle.isOn = model.shouldShowNonSponsoredSuggestions
+                cell.editingAccessoryView = toggle
+                cell.selectionStyle = .none
+            default:
+                // Should not happen.
+                break
+            }
         }
 
         // So that the separator line goes all the way to the left edge.
@@ -147,10 +175,14 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == SectionDefault {
             return NumberOfItemsInSectionDefault
-        } else {
+        } else if section == SectionOrder {
             // The first engine -- the default engine -- is not shown in the quick search engine list.
             // But the option to add Custom Engine is.
             return model.orderedEngines.count
+        } else if section == SectionSuggest {
+            return NumberOfItemsInSectionSuggest
+        } else {
+            return 0
         }
     }
 
@@ -163,7 +195,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             searchEnginePicker.delegate = self
             searchEnginePicker.selectedSearchEngineName = model.defaultEngine.shortName
             navigationController?.pushViewController(searchEnginePicker, animated: true)
-        } else if indexPath.item + 1 == model.orderedEngines.count {
+        } else if indexPath.section == SectionOrder && indexPath.item + 1 == model.orderedEngines.count {
             let customSearchEngineForm = CustomSearchViewController()
             customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
@@ -179,7 +211,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
     // Don't show delete button on the left.
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        if indexPath.section == SectionDefault || indexPath.item + 1 == model.orderedEngines.count {
+        if indexPath.section == SectionDefault || indexPath.section == SectionSuggest || (indexPath.section == SectionOrder && indexPath.item + 1 == model.orderedEngines.count) {
             return UITableViewCell.EditingStyle.none
         }
 
@@ -224,8 +256,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         var sectionTitle: String
         if section == SectionDefault {
             sectionTitle = .SearchSettingsDefaultSearchEngineTitle
-        } else {
+        } else if section == SectionOrder {
             sectionTitle = .SearchSettingsQuickSearchEnginesTitle
+        } else {
+            return nil
         }
         headerView.titleLabel.text = sectionTitle
 
@@ -240,7 +274,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        if indexPath.section == SectionDefault || indexPath.item + 1 == model.orderedEngines.count {
+        if indexPath.section == SectionDefault || indexPath.section == SectionSuggest || (indexPath.section == SectionOrder && indexPath.item + 1 == model.orderedEngines.count) {
             return false
         } else {
             return true
@@ -260,6 +294,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         // You can't drag or drop on the default engine.
         if sourceIndexPath.section == SectionDefault || proposedDestinationIndexPath.section == SectionDefault {
+            return sourceIndexPath
+        }
+
+        if sourceIndexPath.section == SectionSuggest || proposedDestinationIndexPath.section == SectionSuggest {
             return sourceIndexPath
         }
 
@@ -325,6 +363,14 @@ extension SearchSettingsTableViewController {
     @objc func didToggleSearchSuggestions(_ toggle: UISwitch) {
         // Setting the value in settings dismisses any opt-in.
         model.shouldShowSearchSuggestions = toggle.isOn
+    }
+
+    @objc func didToggleSponsoredSuggestions(_ toggle: UISwitch) {
+        model.shouldShowSponsoredSuggestions = toggle.isOn
+    }
+
+    @objc func didToggleNonSponsoredSuggestions(_ toggle: UISwitch) {
+        model.shouldShowNonSponsoredSuggestions = toggle.isOn
     }
 
     func cancel() {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4324,6 +4324,16 @@ extension String {
         tableName: nil,
         value: nil,
         comment: "Title for quick-search engines settings section.")
+    public static let SearchSettingsShowSponsoredSuggestionsLabel = MZLocalizedString(
+        "SearchSettings.Suggest.ShowSponsoredLabel.v999",
+        tableName: nil,
+        value: "Show suggestions from sponsors",
+        comment: "Label for setting to show sponsored suggestions from the Firefox Suggest Service.")
+    public static let SearchSettingsShowNonSponsoredSuggestionsLabel = MZLocalizedString(
+        "SearchSettings.Suggest.ShowNonSponsoredLabel.v999",
+        tableName: nil,
+        value: "Show suggestions from the web",
+        comment: "Label for setting to show non-sponsored suggestions from the Firefox Suggest Service.")
 }
 
 // MARK: - SettingsContent

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -753,8 +753,13 @@ extension String {
             tableName: nil,
             value: "Firefox Suggest",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions.")
-        public static let SponsoredSuggestionLabel = MZLocalizedString(
-            "Search.SponsoredSuggestionLabel.v999",
+        public static let MerinoSuggestionTitle = MZLocalizedString(
+            "Search.MerinoSuggestionTitleLabel.v999",
+            tableName: nil,
+            value: "%1$@ — %2$@",
+            comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used to form the title for a suggestion from the Firefox Suggest Service, using the completed search keyword (1$) and suggested page title (2$).")
+        public static let SponsoredSuggestionDescription = MZLocalizedString(
+            "Search.SponsoredSuggestionDescriptionLabel.v999",
             tableName: nil,
             value: "Sponsored",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a label for sponsored suggestions from the Firefox Suggest Service.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -753,6 +753,11 @@ extension String {
             tableName: nil,
             value: "Firefox Suggest",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions.")
+        public static let SponsoredSuggestionLabel = MZLocalizedString(
+            "Search.SponsoredSuggestionLabel.v999",
+            tableName: nil,
+            value: "Sponsored",
+            comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a label for sponsored suggestions from the Firefox Suggest Service.")
         public static let EngineSectionTitle = MZLocalizedString(
             "Search.EngineSection.Title.v108",
             tableName: "SearchHeaderTitle",

--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -55,6 +55,8 @@ class OneLineTableViewCell: UITableViewCell,
         separatorLine.backgroundColor = UIColor.Photon.Grey40
     }
 
+    var generationNumber = 1
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -125,6 +127,8 @@ class OneLineTableViewCell: UITableViewCell,
         separatorInset = defaultSeparatorInset
         titleLabel.text = nil
         leftImageView.image = nil
+
+        generationNumber += 1
     }
 
     // To simplify setup, OneLineTableViewCell now has a viewModel

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -55,6 +55,8 @@ class TwoLineImageOverlayCell: UITableViewCell,
         label.textAlignment = .natural
     }
 
+    var generationNumber = 1
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
@@ -130,5 +132,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
                                       bottom: 0,
                                       right: 0)
         leftImageView.image = nil
+
+        generationNumber += 1
     }
 }

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -69,6 +69,8 @@ final class NimbusFeatureFlagLayer {
             return checkNimbusForShareSheet(for: featureID, from: nimbus)
         case .creditCardAutofillStatus:
             return checkNimbusForCreditCardAutofill(for: featureID, from: nimbus)
+        case .merino:
+            return false
         }
     }
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -64,6 +64,7 @@ public struct PrefsKeys {
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let TabTrayGroups = "TabTrayGroupsUserPrefsKey"
         public static let TopSiteSection = "TopSitesUserPrefsKey"
+        public static let Merino = "MerinoUserPrefsKey"
     }
 
     public struct LegacyFeatureFlags {
@@ -134,6 +135,8 @@ public struct PrefsKeys {
 
     // The last timestamp we polled FxA for missing send tabs
     public static let PollCommandsTimestamp = "PollCommandsTimestamp"
+
+    public static let CustomMerinoServerURL = "CustomMerinoServerURL"
 }
 
 public struct PrefsDefaults {

--- a/Shared/en-US.lproj/Localizable.strings
+++ b/Shared/en-US.lproj/Localizable.strings
@@ -1087,6 +1087,9 @@
 /* When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions. */
 "Search.SuggestSectionTitle.v102" = "Firefox Suggest";
 
+/* When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a label for sponsored suggestions from the Firefox Suggest Service. */
+"Search.SponsoredSuggestionLabel.v999" = "Sponsored";
+
 /* The message that asks the user to Add the search provider explaining where the search engine will appear */
 "Search.ThirdPartyEngines.AddMessage" = "The new search engine will appear in the quick search bar.";
 

--- a/Shared/en-US.lproj/Localizable.strings
+++ b/Shared/en-US.lproj/Localizable.strings
@@ -1090,8 +1090,10 @@
 /* When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions. */
 "Search.SuggestSectionTitle.v102" = "Firefox Suggest";
 
+/* When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used to form the title for a suggestion from the Firefox Suggest Service, using the completed search keyword (1$) and suggested page title (2$). */
+"Search.MerinoSuggestionTitleLabel.v999" = "%1$@ — %2$@";
 /* When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a label for sponsored suggestions from the Firefox Suggest Service. */
-"Search.SponsoredSuggestionLabel.v999" = "Sponsored";
+"Search.SponsoredSuggestionDescriptionLabel.v999" = "Sponsored";
 
 /* The message that asks the user to Add the search provider explaining where the search engine will appear */
 "Search.ThirdPartyEngines.AddMessage" = "The new search engine will appear in the quick search bar.";

--- a/Shared/en-US.lproj/Localizable.strings
+++ b/Shared/en-US.lproj/Localizable.strings
@@ -1003,6 +1003,9 @@
 /* Title for quick-search engines settings section. */
 "Quick-Search Engines" = "Quick-Search Engines";
 
+"SearchSettings.Suggest.ShowSponsoredLabel.v999" = "Show suggestions from sponsors";
+"SearchSettings.Suggest.ShowNonSponsoredLabel.v999" = "Show suggestions from the web";
+
 /* A label indicating the action that a user can rate the Firefox app in the App store. */
 "Ratings.Settings.RateOnAppStore" = "Rate on App Store";
 

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -58,4 +58,42 @@ class StringExtensionsTests: XCTestCase {
         let strip = HTTPDownload.stripUnicode(fromFilename: file)
         XCTAssert(strip == nounicode)
     }
+
+    func testBoldString() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let text = "abcdefbcde"
+        // The source string contains the substring twice;
+        // `attributedText(boldString:font:)` should only bold the first
+        // occurrence.
+        let attributedText = text.attributedText(boldString: "bcde", font: font)
+        var effectiveRange = NSRange()
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 0, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 0, length: 1))
+
+        XCTAssertEqual(
+            attributedText.attribute(.font, at: 1, effectiveRange: &effectiveRange) as? UIFont,
+            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+        )
+        XCTAssertEqual(effectiveRange, NSRange(location: 1, length: 4))
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 5, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 5, length: 5))
+    }
+
+    func testBoldInRange() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let text = "abcdefbcde"
+        let attributedText = text.attributedText(boldIn: text.index(text.endIndex, offsetBy: -4)..<text.endIndex, font: font)
+        var effectiveRange = NSRange()
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 0, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 0, length: 6))
+
+        XCTAssertEqual(
+            attributedText.attribute(.font, at: 6, effectiveRange: &effectiveRange) as? UIFont,
+            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+        )
+        XCTAssertEqual(effectiveRange, NSRange(location: 6, length: 4))
+    }
 }


### PR DESCRIPTION
Now for iOS!

Getting this working locally is a little trickier—you'll need checkouts of `application-services` (linabutler/application-services#1), `firefox-ios`, _and_ `rust-components-swift` (linabutler/rust-components-swift#1), and Xcode might need a few pokes to pick up all the new directories—but, once everything's set up:

* Open Settings.
* In the About section at the bottom, tap the Firefox version number 5 times to show all the hidden settings.
* Scroll down and tap Merino, then flip the "Enable Merino" switch.
* Go back to the main Settings screen, then scroll up to the General section and open Search.
* Flip the switches for showing sponsored and non-sponsored suggestions.
* Close out of Settings, and try typing something in the address bar!